### PR TITLE
chore: ignore macOS metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 cover.out
 coverage.out
 httpx.dump
+.DS_Store


### PR DESCRIPTION
Adds a repository-wide `.DS_Store` ignore rule so Finder metadata no longer appears in working trees or future commits.