### PR TITLE
docs: use absolute README image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/images/logo.png" width="250" alt="httpx Logo">
+  <img src="https://raw.githubusercontent.com/goforj/httpx/main/docs/images/logo.png" width="250" alt="httpx Logo">
 </p>
 
 A generics-first HTTP client wrapper for Go, built on top of the amazing `github.com/imroc/req/v3` library.


### PR DESCRIPTION
Uses an absolute raw.githubusercontent.com URL for the leading README image so external link-preview scrapers can load the project artwork consistently.