### PR TITLE
feat: add Go 1.27 generic client methods

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ["1.27.x", "stable"]
 
     steps:
       - name: Checkout
@@ -17,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "stable"
+          go-version: ${{ matrix.go-version }}
 
       - name: Install dependencies
         run: go mod tidy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Run tests
         run: go test ./... -v
 
+      - name: Verify generated documentation
+        run: |
+          make generate
+          git diff --exit-code -- README.md examples
+
       - name: Run tests with coverage
         run: go test -coverprofile=coverage.txt
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ vet: ##@analysis Run Go vet.
 ##@documentation
 generate: ##@documentation Regenerate the documentation.
 	go -C docs run ./readme/main.go
+	go -C docs run ./examplegen/main.go
 
 docs-watch: ##@documentation Watch source changes and regenerate documentation.
 	sh docs/watcher.sh

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ It keeps req's power and escape hatches, while making the 90% use case feel effo
     <a href="https://pkg.go.dev/github.com/goforj/httpx/v2"><img src="https://pkg.go.dev/badge/github.com/goforj/httpx/v2.svg" alt="Go Reference"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
     <a href="https://github.com/goforj/httpx/actions"><img src="https://github.com/goforj/httpx/actions/workflows/test.yml/badge.svg" alt="Go Test"></a>
-    <a href="https://golang.org"><img src="https://img.shields.io/badge/go-1.18+-blue?logo=go" alt="Go version"></a>
+    <a href="https://golang.org"><img src="https://img.shields.io/badge/go-1.27+-blue?logo=go" alt="Go version"></a>
     <img src="https://img.shields.io/github/v/tag/goforj/httpx?label=version&sort=semver" alt="Latest tag">
     <a href="https://codecov.io/gh/goforj/httpx" ><img src="https://codecov.io/gh/goforj/httpx/graph/badge.svg?token=R5O7LYAD4B"/></a>
 <!-- test-count:embed:start -->
-    <img src="https://img.shields.io/badge/tests-203-brightgreen" alt="Tests">
+    <img src="https://img.shields.io/badge/tests-223-brightgreen" alt="Tests">
 <!-- test-count:embed:end -->
 </p>
 
@@ -33,7 +33,8 @@ type Request struct {
 }
 
 // request, binds result to Request
-res, _ := httpx.Get[Request](httpx.New(), "https://httpbin.org/uuid")
+c := httpx.New()
+res, _ := c.Get[Request]("https://httpbin.org/uuid")
 
 httpx.Dump(res)
 // #main.Request {
@@ -46,6 +47,8 @@ httpx.Dump(res)
 ```bash
 go get github.com/goforj/httpx/v2
 ```
+
+The generic method API requires Go 1.27 or newer. Projects on older Go releases can pin the v2.0 release line.
 
 ## Design Principles
 
@@ -96,15 +99,15 @@ Use `make test` for the test suite, `make vet` for static checks, and `make gene
 |------:|:-----------|
 | **Auth** | [Auth](#auth) · [Basic](#basic) · [Bearer](#bearer) |
 | **Browser Profiles** | [AsChrome](#aschrome) · [AsFirefox](#asfirefox) · [AsMobile](#asmobile) · [AsSafari](#assafari) |
-| **Client** | [Default](#default) · [New](#new) · [Raw](#raw) · [Req](#req) |
+| **Client** | [Client.Raw](#client-raw) · [Client.Req](#client-req) · [Default](#default) · [New](#new) |
 | **Client Options** | [BaseURL](#baseurl) · [CookieJar](#cookiejar) · [ErrorMapper](#errormapper) · [Middleware](#middleware) · [Proxy](#proxy) · [ProxyFunc](#proxyfunc) · [Redirect](#redirect) · [Transport](#transport) |
 | **Debugging** | [Dump](#dump) · [DumpAll](#dumpall) · [DumpEachRequest](#dumpeachrequest) · [DumpEachRequestTo](#dumpeachrequestto) · [DumpTo](#dumpto) · [DumpToFile](#dumptofile) · [EnableDump](#enabledump) · [Trace](#trace) · [TraceAll](#traceall) |
 | **Download Options** | [OutputFile](#outputfile) |
-| **Errors** | [Error](#error) |
+| **Errors** | [HTTPError.Error](#httperror-error) |
 | **Request Composition** | [Body](#body) · [Form](#form) · [Header](#header) · [Headers](#headers) · [JSON](#json) · [Path](#path) · [Paths](#paths) · [Queries](#queries) · [Query](#query) · [UserAgent](#useragent) |
 | **Request Control** | [Before](#before) · [Timeout](#timeout) |
-| **Requests** | [Delete](#delete) · [Do](#do) · [Get](#get) · [Head](#head) · [Options](#options) · [Patch](#patch) · [Post](#post) · [Put](#put) |
-| **Requests (Context)** | [DeleteCtx](#deletectx) · [GetCtx](#getctx) · [HeadCtx](#headctx) · [OptionsCtx](#optionsctx) · [PatchCtx](#patchctx) · [PostCtx](#postctx) · [PutCtx](#putctx) |
+| **Requests** | [Client.Delete](#client-delete) · [Client.Get](#client-get) · [Client.Head](#client-head) · [Client.Options](#client-options) · [Client.Patch](#client-patch) · [Client.Post](#client-post) · [Client.Put](#client-put) · [Delete](#delete) · [Do](#do) · [Get](#get) · [Head](#head) · [Options](#options) · [Patch](#patch) · [Post](#post) · [Put](#put) |
+| **Requests (Context)** | [Client.DeleteCtx](#client-deletectx) · [Client.GetCtx](#client-getctx) · [Client.HeadCtx](#client-headctx) · [Client.OptionsCtx](#client-optionsctx) · [Client.PatchCtx](#client-patchctx) · [Client.PostCtx](#client-postctx) · [Client.PutCtx](#client-putctx) · [DeleteCtx](#deletectx) · [GetCtx](#getctx) · [HeadCtx](#headctx) · [OptionsCtx](#optionsctx) · [PatchCtx](#patchctx) · [PostCtx](#postctx) · [PutCtx](#putctx) |
 | **Retry** | [RetryBackoff](#retrybackoff) · [RetryCondition](#retrycondition) · [RetryCount](#retrycount) · [RetryFixedInterval](#retryfixedinterval) · [RetryHook](#retryhook) · [RetryInterval](#retryinterval) |
 | **Retry (Client)** | [Retry](#retry) |
 | **Upload Options** | [File](#file) · [FileBytes](#filebytes) · [FileReader](#filereader) · [Files](#files) · [UploadCallback](#uploadcallback) · [UploadCallbackWithInterval](#uploadcallbackwithinterval) · [UploadProgress](#uploadprogress) |
@@ -231,6 +234,14 @@ _ = httpx.New(httpx.AsSafari())
 
 ## Client
 
+### <a id="client-raw"></a>Client.Raw
+
+Raw returns the underlying req client for chaining raw requests.
+
+### <a id="client-req"></a>Client.Req
+
+Req returns the underlying req client for advanced usage.
+
 ### <a id="default"></a>Default
 
 Default returns the shared default client.
@@ -272,14 +283,6 @@ _ = httpx.New(httpx.
 	RetryHook(func(_ *req.Response, _ error) {}),
 )
 ```
-
-### <a id="raw"></a>Raw
-
-Raw returns the underlying req client for chaining raw requests.
-
-### <a id="req"></a>Req
-
-Req returns the underlying req client for advanced usage.
 
 ## Client Options
 
@@ -531,7 +534,7 @@ httpx.Dump(res) // dumps map[string]any
 
 ## Errors
 
-### <a id="error"></a>Error
+### <a id="httperror-error"></a>HTTPError.Error
 
 Error returns a short, human-friendly summary of the HTTP error.
 
@@ -793,9 +796,95 @@ httpx.Dump(res) // dumps map[string]any
 
 ## Requests
 
+### <a id="client-delete"></a>Client.Delete
+
+Delete issues a DELETE request and decodes its response.
+
+```go
+type DeleteResponse struct { URL string `json:"url"` }
+
+c := httpx.New()
+res, err := c.Delete[DeleteResponse]("https://httpbin.org/delete")
+if err != nil {
+	return
+}
+httpx.Dump(res) // dumps DeleteResponse
+```
+
+### <a id="client-get"></a>Client.Get
+
+Get issues a GET request and decodes its response.
+
+```go
+type GetResponse struct {
+	URL string `json:"url"`
+}
+
+c := httpx.New()
+res, _ := c.Get[GetResponse]("https://httpbin.org/get")
+httpx.Dump(res) // dumps GetResponse
+```
+
+### <a id="client-head"></a>Client.Head
+
+Head issues a HEAD request and decodes its response using the established response contract.
+
+### <a id="client-options"></a>Client.Options
+
+Options issues an OPTIONS request and decodes its response.
+
+### <a id="client-patch"></a>Client.Patch
+
+Patch issues a PATCH request and decodes its response.
+
+```go
+type UpdateUser struct { Name string `json:"name"` }
+type UpdateUserResponse struct { JSON UpdateUser `json:"json"` }
+
+c := httpx.New()
+res, err := c.Patch[UpdateUserResponse]("https://httpbin.org/patch", UpdateUser{Name: "Ana"})
+if err != nil {
+	return
+}
+httpx.Dump(res) // dumps UpdateUserResponse
+```
+
+### <a id="client-post"></a>Client.Post
+
+Post issues a POST request and decodes its response.
+
+```go
+type CreateUser struct { Name string `json:"name"` }
+type CreateUserResponse struct { JSON CreateUser `json:"json"` }
+
+c := httpx.New()
+res, err := c.Post[CreateUserResponse]("https://httpbin.org/post", CreateUser{Name: "Ana"})
+if err != nil {
+	return
+}
+httpx.Dump(res) // dumps CreateUserResponse
+```
+
+### <a id="client-put"></a>Client.Put
+
+Put issues a PUT request and decodes its response.
+
+```go
+type UpdateUser struct { Name string `json:"name"` }
+type UpdateUserResponse struct { JSON UpdateUser `json:"json"` }
+
+c := httpx.New()
+res, err := c.Put[UpdateUserResponse]("https://httpbin.org/put", UpdateUser{Name: "Ana"})
+if err != nil {
+	return
+}
+httpx.Dump(res) // dumps UpdateUserResponse
+```
+
 ### <a id="delete"></a>Delete
 
 Delete issues a DELETE request using the provided client.
+It remains available for compatibility; new code can use Client.Delete.
 
 ```go
 type DeleteResponse struct {
@@ -839,6 +928,7 @@ println(rawResp.StatusCode)
 ### <a id="get"></a>Get
 
 Get issues a GET request using the provided client.
+It remains available for compatibility; new code can use Client.Get.
 
 _Example: bind to a struct_
 
@@ -868,6 +958,7 @@ println(resString) // dumps string
 ### <a id="head"></a>Head
 
 Head issues a HEAD request using the provided client.
+It remains available for compatibility; new code can use Client.Head.
 
 ```go
 c := httpx.New()
@@ -880,6 +971,7 @@ if err != nil {
 ### <a id="options"></a>Options
 
 Options issues an OPTIONS request using the provided client.
+It remains available for compatibility; new code can use Client.Options.
 
 ```go
 c := httpx.New()
@@ -892,6 +984,7 @@ if err != nil {
 ### <a id="patch"></a>Patch
 
 Patch issues a PATCH request using the provided client.
+It remains available for compatibility; new code can use Client.Patch.
 
 ```go
 type UpdateUser struct {
@@ -917,6 +1010,7 @@ httpx.Dump(res) // dumps UpdateUserResponse
 ### <a id="post"></a>Post
 
 Post issues a POST request using the provided client.
+It remains available for compatibility; new code can use Client.Post.
 
 ```go
 type CreateUser struct {
@@ -942,6 +1036,7 @@ httpx.Dump(res) // dumps CreateUserResponse
 ### <a id="put"></a>Put
 
 Put issues a PUT request using the provided client.
+It remains available for compatibility; new code can use Client.Put.
 
 ```go
 type UpdateUser struct {
@@ -966,9 +1061,38 @@ httpx.Dump(res) // dumps UpdateUserResponse
 
 ## Requests (Context)
 
+### <a id="client-deletectx"></a>Client.DeleteCtx
+
+DeleteCtx issues a context-aware DELETE request and decodes its response.
+
+### <a id="client-getctx"></a>Client.GetCtx
+
+GetCtx issues a context-aware GET request and decodes its response.
+
+### <a id="client-headctx"></a>Client.HeadCtx
+
+HeadCtx issues a context-aware HEAD request and decodes its response using the established response contract.
+
+### <a id="client-optionsctx"></a>Client.OptionsCtx
+
+OptionsCtx issues a context-aware OPTIONS request and decodes its response.
+
+### <a id="client-patchctx"></a>Client.PatchCtx
+
+PatchCtx issues a context-aware PATCH request and decodes its response.
+
+### <a id="client-postctx"></a>Client.PostCtx
+
+PostCtx issues a context-aware POST request and decodes its response.
+
+### <a id="client-putctx"></a>Client.PutCtx
+
+PutCtx issues a context-aware PUT request and decodes its response.
+
 ### <a id="deletectx"></a>DeleteCtx
 
 DeleteCtx issues a DELETE request using the provided client and context.
+It remains available for compatibility; new code can use Client.DeleteCtx.
 
 ```go
 type DeleteResponse struct {
@@ -990,6 +1114,7 @@ httpx.Dump(res) // dumps DeleteResponse
 ### <a id="getctx"></a>GetCtx
 
 GetCtx issues a GET request using the provided client and context.
+It remains available for compatibility; new code can use Client.GetCtx.
 
 ```go
 type GetResponse struct {
@@ -1011,6 +1136,7 @@ httpx.Dump(res) // dumps GetResponse
 ### <a id="headctx"></a>HeadCtx
 
 HeadCtx issues a HEAD request using the provided client and context.
+It remains available for compatibility; new code can use Client.HeadCtx.
 
 ```go
 ctx := context.Background()
@@ -1024,6 +1150,7 @@ if err != nil {
 ### <a id="optionsctx"></a>OptionsCtx
 
 OptionsCtx issues an OPTIONS request using the provided client and context.
+It remains available for compatibility; new code can use Client.OptionsCtx.
 
 ```go
 ctx := context.Background()
@@ -1037,6 +1164,7 @@ if err != nil {
 ### <a id="patchctx"></a>PatchCtx
 
 PatchCtx issues a PATCH request using the provided client and context.
+It remains available for compatibility; new code can use Client.PatchCtx.
 
 ```go
 type UpdateUser struct {
@@ -1063,6 +1191,7 @@ httpx.Dump(res) // dumps UpdateUserResponse
 ### <a id="postctx"></a>PostCtx
 
 PostCtx issues a POST request using the provided client and context.
+It remains available for compatibility; new code can use Client.PostCtx.
 
 ```go
 type CreateUser struct {
@@ -1089,6 +1218,7 @@ httpx.Dump(res) // dumps CreateUserResponse
 ### <a id="putctx"></a>PutCtx
 
 PutCtx issues a PUT request using the provided client and context.
+It remains available for compatibility; new code can use Client.PutCtx.
 
 ```go
 type UpdateUser struct {

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It keeps req's power and escape hatches, while making the 90% use case feel effo
     <img src="https://img.shields.io/github/v/tag/goforj/httpx?label=version&sort=semver" alt="Latest tag">
     <a href="https://codecov.io/gh/goforj/httpx" ><img src="https://codecov.io/gh/goforj/httpx/graph/badge.svg?token=R5O7LYAD4B"/></a>
 <!-- test-count:embed:start -->
-    <img src="https://img.shields.io/badge/tests-223-brightgreen" alt="Tests">
+    <img src="https://img.shields.io/badge/tests-232-brightgreen" alt="Tests">
 <!-- test-count:embed:end -->
 </p>
 
@@ -808,7 +808,8 @@ res, err := c.Delete[DeleteResponse]("https://httpbin.org/delete")
 if err != nil {
 	return
 }
-httpx.Dump(res) // dumps DeleteResponse
+fmt.Println(res.URL)
+// https://httpbin.org/delete
 ```
 
 ### <a id="client-get"></a>Client.Get
@@ -821,17 +822,32 @@ type GetResponse struct {
 }
 
 c := httpx.New()
-res, _ := c.Get[GetResponse]("https://httpbin.org/get")
-httpx.Dump(res) // dumps GetResponse
+res, err := c.Get[GetResponse]("https://httpbin.org/get")
+fmt.Println(err == nil, res.URL)
+// true https://httpbin.org/get
 ```
 
 ### <a id="client-head"></a>Client.Head
 
 Head issues a HEAD request and decodes its response using the established response contract.
 
+```go
+c := httpx.New()
+_, err := c.Head[[]byte]("https://httpbin.org/get")
+fmt.Println(err == nil)
+// true
+```
+
 ### <a id="client-options"></a>Client.Options
 
 Options issues an OPTIONS request and decodes its response.
+
+```go
+c := httpx.New()
+_, err := c.Options[[]byte]("https://httpbin.org/get")
+fmt.Println(err == nil)
+// true
+```
 
 ### <a id="client-patch"></a>Client.Patch
 
@@ -846,7 +862,8 @@ res, err := c.Patch[UpdateUserResponse]("https://httpbin.org/patch", UpdateUser{
 if err != nil {
 	return
 }
-httpx.Dump(res) // dumps UpdateUserResponse
+fmt.Println(res.JSON.Name)
+// Ana
 ```
 
 ### <a id="client-post"></a>Client.Post
@@ -862,7 +879,8 @@ res, err := c.Post[CreateUserResponse]("https://httpbin.org/post", CreateUser{Na
 if err != nil {
 	return
 }
-httpx.Dump(res) // dumps CreateUserResponse
+fmt.Println(res.JSON.Name)
+// Ana
 ```
 
 ### <a id="client-put"></a>Client.Put
@@ -878,7 +896,8 @@ res, err := c.Put[UpdateUserResponse]("https://httpbin.org/put", UpdateUser{Name
 if err != nil {
 	return
 }
-httpx.Dump(res) // dumps UpdateUserResponse
+fmt.Println(res.JSON.Name)
+// Ana
 ```
 
 ### <a id="delete"></a>Delete
@@ -1065,29 +1084,109 @@ httpx.Dump(res) // dumps UpdateUserResponse
 
 DeleteCtx issues a context-aware DELETE request and decodes its response.
 
+```go
+type DeleteResponse struct {
+	URL string `json:"url"`
+}
+ctx := context.Background()
+c := httpx.New()
+res, err := c.DeleteCtx[DeleteResponse](ctx, "https://httpbin.org/delete")
+if err != nil {
+	return
+}
+fmt.Println(res.URL)
+// https://httpbin.org/delete
+```
+
 ### <a id="client-getctx"></a>Client.GetCtx
 
 GetCtx issues a context-aware GET request and decodes its response.
+
+```go
+type GetResponse struct {
+	URL string `json:"url"`
+}
+ctx := context.Background()
+c := httpx.New()
+res, err := c.GetCtx[GetResponse](ctx, "https://httpbin.org/get")
+fmt.Println(err == nil, res.URL)
+// true https://httpbin.org/get
+```
 
 ### <a id="client-headctx"></a>Client.HeadCtx
 
 HeadCtx issues a context-aware HEAD request and decodes its response using the established response contract.
 
+```go
+ctx := context.Background()
+c := httpx.New()
+_, err := c.HeadCtx[[]byte](ctx, "https://httpbin.org/get")
+fmt.Println(err == nil)
+// true
+```
+
 ### <a id="client-optionsctx"></a>Client.OptionsCtx
 
 OptionsCtx issues a context-aware OPTIONS request and decodes its response.
+
+```go
+ctx := context.Background()
+c := httpx.New()
+_, err := c.OptionsCtx[[]byte](ctx, "https://httpbin.org/get")
+fmt.Println(err == nil)
+// true
+```
 
 ### <a id="client-patchctx"></a>Client.PatchCtx
 
 PatchCtx issues a context-aware PATCH request and decodes its response.
 
+```go
+type UpdateUser struct { Name string `json:"name"` }
+type UpdateUserResponse struct { JSON UpdateUser `json:"json"` }
+ctx := context.Background()
+c := httpx.New()
+res, err := c.PatchCtx[UpdateUserResponse](ctx, "https://httpbin.org/patch", UpdateUser{Name: "Ana"})
+if err != nil {
+	return
+}
+fmt.Println(res.JSON.Name)
+// Ana
+```
+
 ### <a id="client-postctx"></a>Client.PostCtx
 
 PostCtx issues a context-aware POST request and decodes its response.
 
+```go
+type CreateUser struct { Name string `json:"name"` }
+type CreateUserResponse struct { JSON CreateUser `json:"json"` }
+ctx := context.Background()
+c := httpx.New()
+res, err := c.PostCtx[CreateUserResponse](ctx, "https://httpbin.org/post", CreateUser{Name: "Ana"})
+if err != nil {
+	return
+}
+fmt.Println(res.JSON.Name)
+// Ana
+```
+
 ### <a id="client-putctx"></a>Client.PutCtx
 
 PutCtx issues a context-aware PUT request and decodes its response.
+
+```go
+type UpdateUser struct { Name string `json:"name"` }
+type UpdateUserResponse struct { JSON UpdateUser `json:"json"` }
+ctx := context.Background()
+c := httpx.New()
+res, err := c.PutCtx[UpdateUserResponse](ctx, "https://httpbin.org/put", UpdateUser{Name: "Ana"})
+if err != nil {
+	return
+}
+fmt.Println(res.JSON.Name)
+// Ana
+```
 
 ### <a id="deletectx"></a>DeleteCtx
 

--- a/client.go
+++ b/client.go
@@ -109,6 +109,7 @@ func (c *Client) clone() *Client {
 }
 
 // Get issues a GET request using the provided client.
+// It remains available for compatibility; new code can use Client.Get.
 // @group Requests
 //
 // Example: bind to a struct
@@ -137,6 +138,7 @@ func Get[T any](client *Client, url string, opts ...Option) (T, error) {
 }
 
 // Post issues a POST request using the provided client.
+// It remains available for compatibility; new code can use Client.Post.
 // @group Requests
 //
 // Example: typed POST
@@ -165,6 +167,7 @@ func Post[In any, Out any](client *Client, url string, body In, opts ...Option) 
 }
 
 // Put issues a PUT request using the provided client.
+// It remains available for compatibility; new code can use Client.Put.
 // @group Requests
 //
 // Example: typed PUT
@@ -193,6 +196,7 @@ func Put[In any, Out any](client *Client, url string, body In, opts ...Option) (
 }
 
 // Patch issues a PATCH request using the provided client.
+// It remains available for compatibility; new code can use Client.Patch.
 // @group Requests
 //
 // Example: typed PATCH
@@ -221,6 +225,7 @@ func Patch[In any, Out any](client *Client, url string, body In, opts ...Option)
 }
 
 // Delete issues a DELETE request using the provided client.
+// It remains available for compatibility; new code can use Client.Delete.
 // @group Requests
 //
 // Example: typed DELETE
@@ -244,6 +249,7 @@ func Delete[T any](client *Client, url string, opts ...Option) (T, error) {
 }
 
 // Head issues a HEAD request using the provided client.
+// It remains available for compatibility; new code can use Client.Head.
 // @group Requests
 //
 // Example: HEAD request
@@ -259,6 +265,7 @@ func Head[T any](client *Client, url string, opts ...Option) (T, error) {
 }
 
 // Options issues an OPTIONS request using the provided client.
+// It remains available for compatibility; new code can use Client.Options.
 // @group Requests
 //
 // Example: OPTIONS request
@@ -274,6 +281,7 @@ func Options[T any](client *Client, url string, opts ...Option) (T, error) {
 }
 
 // GetCtx issues a GET request using the provided client and context.
+// It remains available for compatibility; new code can use Client.GetCtx.
 // @group Requests (Context)
 //
 // Example: context-aware GET
@@ -298,6 +306,7 @@ func GetCtx[T any](client *Client, ctx context.Context, url string, opts ...Opti
 }
 
 // PostCtx issues a POST request using the provided client and context.
+// It remains available for compatibility; new code can use Client.PostCtx.
 // @group Requests (Context)
 //
 // Example: context-aware POST
@@ -327,6 +336,7 @@ func PostCtx[In any, Out any](client *Client, ctx context.Context, url string, b
 }
 
 // PutCtx issues a PUT request using the provided client and context.
+// It remains available for compatibility; new code can use Client.PutCtx.
 // @group Requests (Context)
 //
 // Example: context-aware PUT
@@ -356,6 +366,7 @@ func PutCtx[In any, Out any](client *Client, ctx context.Context, url string, bo
 }
 
 // PatchCtx issues a PATCH request using the provided client and context.
+// It remains available for compatibility; new code can use Client.PatchCtx.
 // @group Requests (Context)
 //
 // Example: context-aware PATCH
@@ -385,6 +396,7 @@ func PatchCtx[In any, Out any](client *Client, ctx context.Context, url string, 
 }
 
 // DeleteCtx issues a DELETE request using the provided client and context.
+// It remains available for compatibility; new code can use Client.DeleteCtx.
 // @group Requests (Context)
 //
 // Example: context-aware DELETE
@@ -409,6 +421,7 @@ func DeleteCtx[T any](client *Client, ctx context.Context, url string, opts ...O
 }
 
 // HeadCtx issues a HEAD request using the provided client and context.
+// It remains available for compatibility; new code can use Client.HeadCtx.
 // @group Requests (Context)
 //
 // Example: context-aware HEAD
@@ -425,6 +438,7 @@ func HeadCtx[T any](client *Client, ctx context.Context, url string, opts ...Opt
 }
 
 // OptionsCtx issues an OPTIONS request using the provided client and context.
+// It remains available for compatibility; new code can use Client.OptionsCtx.
 // @group Requests (Context)
 //
 // Example: context-aware OPTIONS

--- a/docs/examplegen/main.go
+++ b/docs/examplegen/main.go
@@ -127,6 +127,7 @@ func modulePath(root string) (string, error) {
 
 type FuncDoc struct {
 	Name        string
+	Slug        string
 	Group       string
 	Description string
 	Examples    []Example
@@ -173,8 +174,10 @@ func extractFuncDocs(
 			continue
 		}
 
-		out[name] = &FuncDoc{
+		slug := funcSlug(fn)
+		out[slug] = &FuncDoc{
 			Name:        name,
+			Slug:        slug,
 			Group:       extractGroup(fn.Doc),
 			Description: extractFuncDescription(fn.Doc),
 			Examples:    extractBlocks(fset, filename, name, fn),
@@ -182,6 +185,36 @@ func extractFuncDocs(
 	}
 
 	return out
+}
+
+// funcSlug includes receiver identity so methods cannot collide with package functions.
+func funcSlug(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return fn.Name.Name
+	}
+	receiver := receiverTypeName(fn.Recv.List[0].Type)
+	if receiver == "" {
+		return fn.Name.Name
+	}
+	return receiver + "_" + fn.Name.Name
+}
+
+// receiverTypeName unwraps receiver syntax into the name used for generated example directories.
+func receiverTypeName(expr ast.Expr) string {
+	switch value := expr.(type) {
+	case *ast.Ident:
+		return value.Name
+	case *ast.ParenExpr:
+		return receiverTypeName(value.X)
+	case *ast.StarExpr:
+		return receiverTypeName(value.X)
+	case *ast.IndexExpr:
+		return receiverTypeName(value.X)
+	case *ast.IndexListExpr:
+		return receiverTypeName(value.X)
+	default:
+		return ""
+	}
 }
 
 func extractGroup(group *ast.CommentGroup) string {
@@ -362,7 +395,7 @@ func writeMain(base string, fd *FuncDoc, importPath string) error {
 		return fmt.Errorf("import path cannot be empty")
 	}
 
-	dir := filepath.Join(base, strings.ToLower(fd.Name))
+	dir := filepath.Join(base, strings.ToLower(fd.Slug))
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}

--- a/docs/readme/main.go
+++ b/docs/readme/main.go
@@ -77,7 +77,10 @@ func run() error {
 //
 
 type FuncDoc struct {
+	Key         string
 	Name        string
+	DisplayName string
+	Anchor      string
 	Group       string
 	Behavior    string
 	Fluent      string
@@ -142,8 +145,21 @@ func parseFuncs(root string) ([]*FuncDoc, error) {
 				continue
 			}
 
+			receiver := extractReceiverName(fn)
+			displayName := fn.Name.Name
+			anchor := strings.ToLower(fn.Name.Name)
+			key := fn.Name.Name
+			if receiver != "" {
+				displayName = receiver + "." + fn.Name.Name
+				anchor = strings.ToLower(receiver + "-" + fn.Name.Name)
+				key = receiver + "." + fn.Name.Name
+			}
+
 			fd := &FuncDoc{
+				Key:         key,
 				Name:        fn.Name.Name,
+				DisplayName: displayName,
+				Anchor:      anchor,
 				Group:       extractGroup(fn.Doc),
 				Behavior:    extractBehavior(fn.Doc),
 				Fluent:      extractFluent(fn.Doc),
@@ -151,10 +167,10 @@ func parseFuncs(root string) ([]*FuncDoc, error) {
 				Examples:    extractExamples(fset, fn),
 			}
 
-			if existing, ok := funcs[fd.Name]; ok {
+			if existing, ok := funcs[fd.Key]; ok {
 				existing.Examples = append(existing.Examples, fd.Examples...)
 			} else {
-				funcs[fd.Name] = fd
+				funcs[fd.Key] = fd
 			}
 		}
 	}
@@ -168,6 +184,32 @@ func parseFuncs(root string) ([]*FuncDoc, error) {
 	}
 
 	return out, nil
+}
+
+// extractReceiverName returns the receiver identifier used to distinguish methods from package functions.
+func extractReceiverName(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return ""
+	}
+	return receiverTypeName(fn.Recv.List[0].Type)
+}
+
+// receiverTypeName unwraps receiver syntax into the named type used by documentation anchors.
+func receiverTypeName(expr ast.Expr) string {
+	switch value := expr.(type) {
+	case *ast.Ident:
+		return value.Name
+	case *ast.ParenExpr:
+		return receiverTypeName(value.X)
+	case *ast.StarExpr:
+		return receiverTypeName(value.X)
+	case *ast.IndexExpr:
+		return receiverTypeName(value.X)
+	case *ast.IndexListExpr:
+		return receiverTypeName(value.X)
+	default:
+		return ""
+	}
 }
 
 func extractGroup(group *ast.CommentGroup) string {
@@ -351,12 +393,12 @@ func renderAPI(funcs []*FuncDoc) string {
 
 	for _, group := range groupNames {
 		sort.Slice(byGroup[group], func(i, j int) bool {
-			return byGroup[group][i].Name < byGroup[group][j].Name
+			return byGroup[group][i].DisplayName < byGroup[group][j].DisplayName
 		})
 
 		var links []string
 		for _, fn := range byGroup[group] {
-			links = append(links, fmt.Sprintf("[%s](#%s)", fn.Name, strings.ToLower(fn.Name)))
+			links = append(links, fmt.Sprintf("[%s](#%s)", fn.DisplayName, fn.Anchor))
 		}
 
 		buf.WriteString(fmt.Sprintf("| **%s** | %s |\n",
@@ -372,9 +414,9 @@ func renderAPI(funcs []*FuncDoc) string {
 		buf.WriteString("## " + group + "\n\n")
 
 		for _, fn := range byGroup[group] {
-			anchor := strings.ToLower(fn.Name)
+			anchor := fn.Anchor
 
-			header := fn.Name
+			header := fn.DisplayName
 			if fn.Behavior != "" {
 				header += " · " + fn.Behavior
 			}

--- a/examples/client_delete/main.go
+++ b/examples/client_delete/main.go
@@ -1,0 +1,22 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import "github.com/goforj/httpx/v2"
+
+func main() {
+	// Delete issues a DELETE request and decodes its response.
+
+	// Example: typed DELETE
+	type DeleteResponse struct {
+		URL string `json:"url"`
+	}
+
+	c := httpx.New()
+	res, err := c.Delete[DeleteResponse]("https://httpbin.org/delete")
+	if err != nil {
+		return
+	}
+	httpx.Dump(res) // dumps DeleteResponse
+}

--- a/examples/client_deletectx/main.go
+++ b/examples/client_deletectx/main.go
@@ -4,20 +4,21 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"github.com/goforj/httpx/v2"
 )
 
 func main() {
-	// Delete issues a DELETE request and decodes its response.
+	// DeleteCtx issues a context-aware DELETE request and decodes its response.
 
-	// Example: typed DELETE
+	// Example: client context-aware DELETE
 	type DeleteResponse struct {
 		URL string `json:"url"`
 	}
-
+	ctx := context.Background()
 	c := httpx.New()
-	res, err := c.Delete[DeleteResponse]("https://httpbin.org/delete")
+	res, err := c.DeleteCtx[DeleteResponse](ctx, "https://httpbin.org/delete")
 	if err != nil {
 		return
 	}

--- a/examples/client_get/main.go
+++ b/examples/client_get/main.go
@@ -1,0 +1,19 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import "github.com/goforj/httpx/v2"
+
+func main() {
+	// Get issues a GET request and decodes its response.
+
+	// Example: bind to a struct
+	type GetResponse struct {
+		URL string `json:"url"`
+	}
+
+	c := httpx.New()
+	res, _ := c.Get[GetResponse]("https://httpbin.org/get")
+	httpx.Dump(res) // dumps GetResponse
+}

--- a/examples/client_getctx/main.go
+++ b/examples/client_getctx/main.go
@@ -4,20 +4,21 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"github.com/goforj/httpx/v2"
 )
 
 func main() {
-	// Get issues a GET request and decodes its response.
+	// GetCtx issues a context-aware GET request and decodes its response.
 
-	// Example: bind to a struct
+	// Example: client context-aware GET
 	type GetResponse struct {
 		URL string `json:"url"`
 	}
-
+	ctx := context.Background()
 	c := httpx.New()
-	res, err := c.Get[GetResponse]("https://httpbin.org/get")
+	res, err := c.GetCtx[GetResponse](ctx, "https://httpbin.org/get")
 	fmt.Println(err == nil, res.URL)
 	// true https://httpbin.org/get
 }

--- a/examples/client_head/main.go
+++ b/examples/client_head/main.go
@@ -1,0 +1,19 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"fmt"
+	"github.com/goforj/httpx/v2"
+)
+
+func main() {
+	// Head issues a HEAD request and decodes its response using the established response contract.
+
+	// Example: client HEAD request
+	c := httpx.New()
+	_, err := c.Head[[]byte]("https://httpbin.org/get")
+	fmt.Println(err == nil)
+	// true
+}

--- a/examples/client_headctx/main.go
+++ b/examples/client_headctx/main.go
@@ -1,0 +1,21 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/goforj/httpx/v2"
+)
+
+func main() {
+	// HeadCtx issues a context-aware HEAD request and decodes its response using the established response contract.
+
+	// Example: client context-aware HEAD
+	ctx := context.Background()
+	c := httpx.New()
+	_, err := c.HeadCtx[[]byte](ctx, "https://httpbin.org/get")
+	fmt.Println(err == nil)
+	// true
+}

--- a/examples/client_options/main.go
+++ b/examples/client_options/main.go
@@ -1,0 +1,19 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"fmt"
+	"github.com/goforj/httpx/v2"
+)
+
+func main() {
+	// Options issues an OPTIONS request and decodes its response.
+
+	// Example: client OPTIONS request
+	c := httpx.New()
+	_, err := c.Options[[]byte]("https://httpbin.org/get")
+	fmt.Println(err == nil)
+	// true
+}

--- a/examples/client_optionsctx/main.go
+++ b/examples/client_optionsctx/main.go
@@ -1,0 +1,21 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/goforj/httpx/v2"
+)
+
+func main() {
+	// OptionsCtx issues a context-aware OPTIONS request and decodes its response.
+
+	// Example: client context-aware OPTIONS
+	ctx := context.Background()
+	c := httpx.New()
+	_, err := c.OptionsCtx[[]byte](ctx, "https://httpbin.org/get")
+	fmt.Println(err == nil)
+	// true
+}

--- a/examples/client_patch/main.go
+++ b/examples/client_patch/main.go
@@ -6,8 +6,7 @@ package main
 import "github.com/goforj/httpx/v2"
 
 func main() {
-	// Patch issues a PATCH request using the provided client.
-	// It remains available for compatibility; new code can use Client.Patch.
+	// Patch issues a PATCH request and decodes its response.
 
 	// Example: typed PATCH
 	type UpdateUser struct {
@@ -18,14 +17,9 @@ func main() {
 	}
 
 	c := httpx.New()
-	res, err := httpx.Patch[UpdateUser, UpdateUserResponse](c, "https://httpbin.org/patch", UpdateUser{Name: "Ana"})
+	res, err := c.Patch[UpdateUserResponse]("https://httpbin.org/patch", UpdateUser{Name: "Ana"})
 	if err != nil {
 		return
 	}
 	httpx.Dump(res) // dumps UpdateUserResponse
-	// #UpdateUserResponse {
-	//   JSON => #UpdateUser {
-	//     Name => "Ana" #string
-	//   }
-	// }
 }

--- a/examples/client_patchctx/main.go
+++ b/examples/client_patchctx/main.go
@@ -4,23 +4,24 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"github.com/goforj/httpx/v2"
 )
 
 func main() {
-	// Patch issues a PATCH request and decodes its response.
+	// PatchCtx issues a context-aware PATCH request and decodes its response.
 
-	// Example: typed PATCH
+	// Example: client context-aware PATCH
 	type UpdateUser struct {
 		Name string `json:"name"`
 	}
 	type UpdateUserResponse struct {
 		JSON UpdateUser `json:"json"`
 	}
-
+	ctx := context.Background()
 	c := httpx.New()
-	res, err := c.Patch[UpdateUserResponse]("https://httpbin.org/patch", UpdateUser{Name: "Ana"})
+	res, err := c.PatchCtx[UpdateUserResponse](ctx, "https://httpbin.org/patch", UpdateUser{Name: "Ana"})
 	if err != nil {
 		return
 	}

--- a/examples/client_post/main.go
+++ b/examples/client_post/main.go
@@ -6,8 +6,7 @@ package main
 import "github.com/goforj/httpx/v2"
 
 func main() {
-	// Post issues a POST request using the provided client.
-	// It remains available for compatibility; new code can use Client.Post.
+	// Post issues a POST request and decodes its response.
 
 	// Example: typed POST
 	type CreateUser struct {
@@ -18,14 +17,9 @@ func main() {
 	}
 
 	c := httpx.New()
-	res, err := httpx.Post[CreateUser, CreateUserResponse](c, "https://httpbin.org/post", CreateUser{Name: "Ana"})
+	res, err := c.Post[CreateUserResponse]("https://httpbin.org/post", CreateUser{Name: "Ana"})
 	if err != nil {
 		return
 	}
 	httpx.Dump(res) // dumps CreateUserResponse
-	// #CreateUserResponse {
-	//   JSON => #CreateUser {
-	//     Name => "Ana" #string
-	//   }
-	// }
 }

--- a/examples/client_postctx/main.go
+++ b/examples/client_postctx/main.go
@@ -4,23 +4,24 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"github.com/goforj/httpx/v2"
 )
 
 func main() {
-	// Post issues a POST request and decodes its response.
+	// PostCtx issues a context-aware POST request and decodes its response.
 
-	// Example: typed POST
+	// Example: client context-aware POST
 	type CreateUser struct {
 		Name string `json:"name"`
 	}
 	type CreateUserResponse struct {
 		JSON CreateUser `json:"json"`
 	}
-
+	ctx := context.Background()
 	c := httpx.New()
-	res, err := c.Post[CreateUserResponse]("https://httpbin.org/post", CreateUser{Name: "Ana"})
+	res, err := c.PostCtx[CreateUserResponse](ctx, "https://httpbin.org/post", CreateUser{Name: "Ana"})
 	if err != nil {
 		return
 	}

--- a/examples/client_put/main.go
+++ b/examples/client_put/main.go
@@ -3,7 +3,10 @@
 
 package main
 
-import "github.com/goforj/httpx/v2"
+import (
+	"fmt"
+	"github.com/goforj/httpx/v2"
+)
 
 func main() {
 	// Put issues a PUT request and decodes its response.
@@ -21,5 +24,6 @@ func main() {
 	if err != nil {
 		return
 	}
-	httpx.Dump(res) // dumps UpdateUserResponse
+	fmt.Println(res.JSON.Name)
+	// Ana
 }

--- a/examples/client_put/main.go
+++ b/examples/client_put/main.go
@@ -6,8 +6,7 @@ package main
 import "github.com/goforj/httpx/v2"
 
 func main() {
-	// Put issues a PUT request using the provided client.
-	// It remains available for compatibility; new code can use Client.Put.
+	// Put issues a PUT request and decodes its response.
 
 	// Example: typed PUT
 	type UpdateUser struct {
@@ -18,14 +17,9 @@ func main() {
 	}
 
 	c := httpx.New()
-	res, err := httpx.Put[UpdateUser, UpdateUserResponse](c, "https://httpbin.org/put", UpdateUser{Name: "Ana"})
+	res, err := c.Put[UpdateUserResponse]("https://httpbin.org/put", UpdateUser{Name: "Ana"})
 	if err != nil {
 		return
 	}
 	httpx.Dump(res) // dumps UpdateUserResponse
-	// #UpdateUserResponse {
-	//   JSON => #UpdateUser {
-	//     Name => "Ana" #string
-	//   }
-	// }
 }

--- a/examples/client_putctx/main.go
+++ b/examples/client_putctx/main.go
@@ -4,23 +4,24 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"github.com/goforj/httpx/v2"
 )
 
 func main() {
-	// Patch issues a PATCH request and decodes its response.
+	// PutCtx issues a context-aware PUT request and decodes its response.
 
-	// Example: typed PATCH
+	// Example: client context-aware PUT
 	type UpdateUser struct {
 		Name string `json:"name"`
 	}
 	type UpdateUserResponse struct {
 		JSON UpdateUser `json:"json"`
 	}
-
+	ctx := context.Background()
 	c := httpx.New()
-	res, err := c.Patch[UpdateUserResponse]("https://httpbin.org/patch", UpdateUser{Name: "Ana"})
+	res, err := c.PutCtx[UpdateUserResponse](ctx, "https://httpbin.org/put", UpdateUser{Name: "Ana"})
 	if err != nil {
 		return
 	}

--- a/examples/delete/main.go
+++ b/examples/delete/main.go
@@ -7,6 +7,7 @@ import "github.com/goforj/httpx/v2"
 
 func main() {
 	// Delete issues a DELETE request using the provided client.
+	// It remains available for compatibility; new code can use Client.Delete.
 
 	// Example: typed DELETE
 	type DeleteResponse struct {

--- a/examples/deletectx/main.go
+++ b/examples/deletectx/main.go
@@ -10,6 +10,7 @@ import (
 
 func main() {
 	// DeleteCtx issues a DELETE request using the provided client and context.
+	// It remains available for compatibility; new code can use Client.DeleteCtx.
 
 	// Example: context-aware DELETE
 	type DeleteResponse struct {

--- a/examples/get/main.go
+++ b/examples/get/main.go
@@ -7,6 +7,7 @@ import "github.com/goforj/httpx/v2"
 
 func main() {
 	// Get issues a GET request using the provided client.
+	// It remains available for compatibility; new code can use Client.Get.
 
 	// Example: bind to a struct
 	type GetResponse struct {

--- a/examples/getctx/main.go
+++ b/examples/getctx/main.go
@@ -10,6 +10,7 @@ import (
 
 func main() {
 	// GetCtx issues a GET request using the provided client and context.
+	// It remains available for compatibility; new code can use Client.GetCtx.
 
 	// Example: context-aware GET
 	type GetResponse struct {

--- a/examples/head/main.go
+++ b/examples/head/main.go
@@ -7,6 +7,7 @@ import "github.com/goforj/httpx/v2"
 
 func main() {
 	// Head issues a HEAD request using the provided client.
+	// It remains available for compatibility; new code can use Client.Head.
 
 	// Example: HEAD request
 	c := httpx.New()

--- a/examples/headctx/main.go
+++ b/examples/headctx/main.go
@@ -10,6 +10,7 @@ import (
 
 func main() {
 	// HeadCtx issues a HEAD request using the provided client and context.
+	// It remains available for compatibility; new code can use Client.HeadCtx.
 
 	// Example: context-aware HEAD
 	ctx := context.Background()

--- a/examples/httperror_error/main.go
+++ b/examples/httperror_error/main.go
@@ -1,0 +1,27 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"errors"
+	"github.com/goforj/httpx/v2"
+)
+
+func main() {
+	// Error returns a short, human-friendly summary of the HTTP error.
+
+	// Example: check for HTTP errors
+	type User struct {
+		Name string `json:"name"`
+	}
+
+	c := httpx.New()
+	res, err := httpx.Get[map[string]any](c, "https://httpbin.org/status/404")
+	httpx.Dump(res) // dumps map[string]any
+	// map[string]interface {}(nil)
+	var httpErr *httpx.HTTPError
+	if errors.As(err, &httpErr) {
+		_ = httpErr.StatusCode
+	}
+}

--- a/examples/options/main.go
+++ b/examples/options/main.go
@@ -7,6 +7,7 @@ import "github.com/goforj/httpx/v2"
 
 func main() {
 	// Options issues an OPTIONS request using the provided client.
+	// It remains available for compatibility; new code can use Client.Options.
 
 	// Example: OPTIONS request
 	c := httpx.New()

--- a/examples/optionsctx/main.go
+++ b/examples/optionsctx/main.go
@@ -10,6 +10,7 @@ import (
 
 func main() {
 	// OptionsCtx issues an OPTIONS request using the provided client and context.
+	// It remains available for compatibility; new code can use Client.OptionsCtx.
 
 	// Example: context-aware OPTIONS
 	ctx := context.Background()

--- a/examples/patchctx/main.go
+++ b/examples/patchctx/main.go
@@ -10,6 +10,7 @@ import (
 
 func main() {
 	// PatchCtx issues a PATCH request using the provided client and context.
+	// It remains available for compatibility; new code can use Client.PatchCtx.
 
 	// Example: context-aware PATCH
 	type UpdateUser struct {

--- a/examples/postctx/main.go
+++ b/examples/postctx/main.go
@@ -10,6 +10,7 @@ import (
 
 func main() {
 	// PostCtx issues a POST request using the provided client and context.
+	// It remains available for compatibility; new code can use Client.PostCtx.
 
 	// Example: context-aware POST
 	type CreateUser struct {

--- a/examples/putctx/main.go
+++ b/examples/putctx/main.go
@@ -10,6 +10,7 @@ import (
 
 func main() {
 	// PutCtx issues a PUT request using the provided client and context.
+	// It remains available for compatibility; new code can use Client.PutCtx.
 
 	// Example: context-aware PUT
 	type UpdateUser struct {

--- a/generic_methods.go
+++ b/generic_methods.go
@@ -12,8 +12,9 @@ import "context"
 //	}
 //
 //	c := httpx.New()
-//	res, _ := c.Get[GetResponse]("https://httpbin.org/get")
-//	httpx.Dump(res) // dumps GetResponse
+//	res, err := c.Get[GetResponse]("https://httpbin.org/get")
+//	fmt.Println(err == nil, res.URL)
+//	// true https://httpbin.org/get
 func (c *Client) Get[Out any](url string, opts ...Option) (Out, error) {
 	body, _, err := do[Out](c, nil, methodGet, url, nil, opts)
 	return body, err
@@ -32,7 +33,8 @@ func (c *Client) Get[Out any](url string, opts ...Option) (Out, error) {
 //	if err != nil {
 //		return
 //	}
-//	httpx.Dump(res) // dumps CreateUserResponse
+//	fmt.Println(res.JSON.Name)
+//	// Ana
 func (c *Client) Post[Out any](url string, body any, opts ...Option) (Out, error) {
 	out, _, err := do[Out](c, nil, methodPost, url, body, opts)
 	return out, err
@@ -51,7 +53,8 @@ func (c *Client) Post[Out any](url string, body any, opts ...Option) (Out, error
 //	if err != nil {
 //		return
 //	}
-//	httpx.Dump(res) // dumps UpdateUserResponse
+//	fmt.Println(res.JSON.Name)
+//	// Ana
 func (c *Client) Put[Out any](url string, body any, opts ...Option) (Out, error) {
 	out, _, err := do[Out](c, nil, methodPut, url, body, opts)
 	return out, err
@@ -70,7 +73,8 @@ func (c *Client) Put[Out any](url string, body any, opts ...Option) (Out, error)
 //	if err != nil {
 //		return
 //	}
-//	httpx.Dump(res) // dumps UpdateUserResponse
+//	fmt.Println(res.JSON.Name)
+//	// Ana
 func (c *Client) Patch[Out any](url string, body any, opts ...Option) (Out, error) {
 	out, _, err := do[Out](c, nil, methodPatch, url, body, opts)
 	return out, err
@@ -88,7 +92,8 @@ func (c *Client) Patch[Out any](url string, body any, opts ...Option) (Out, erro
 //	if err != nil {
 //		return
 //	}
-//	httpx.Dump(res) // dumps DeleteResponse
+//	fmt.Println(res.URL)
+//	// https://httpbin.org/delete
 func (c *Client) Delete[Out any](url string, opts ...Option) (Out, error) {
 	body, _, err := do[Out](c, nil, methodDelete, url, nil, opts)
 	return body, err
@@ -96,6 +101,13 @@ func (c *Client) Delete[Out any](url string, opts ...Option) (Out, error) {
 
 // Head issues a HEAD request and decodes its response using the established response contract.
 // @group Requests
+//
+// Example: client HEAD request
+//
+//	c := httpx.New()
+//	_, err := c.Head[[]byte]("https://httpbin.org/get")
+//	fmt.Println(err == nil)
+//	// true
 func (c *Client) Head[Out any](url string, opts ...Option) (Out, error) {
 	body, _, err := do[Out](c, nil, methodHead, url, nil, opts)
 	return body, err
@@ -103,6 +115,13 @@ func (c *Client) Head[Out any](url string, opts ...Option) (Out, error) {
 
 // Options issues an OPTIONS request and decodes its response.
 // @group Requests
+//
+// Example: client OPTIONS request
+//
+//	c := httpx.New()
+//	_, err := c.Options[[]byte]("https://httpbin.org/get")
+//	fmt.Println(err == nil)
+//	// true
 func (c *Client) Options[Out any](url string, opts ...Option) (Out, error) {
 	body, _, err := do[Out](c, nil, methodOptions, url, nil, opts)
 	return body, err
@@ -110,6 +129,17 @@ func (c *Client) Options[Out any](url string, opts ...Option) (Out, error) {
 
 // GetCtx issues a context-aware GET request and decodes its response.
 // @group Requests (Context)
+//
+// Example: client context-aware GET
+//
+//	type GetResponse struct {
+//		URL string `json:"url"`
+//	}
+//	ctx := context.Background()
+//	c := httpx.New()
+//	res, err := c.GetCtx[GetResponse](ctx, "https://httpbin.org/get")
+//	fmt.Println(err == nil, res.URL)
+//	// true https://httpbin.org/get
 func (c *Client) GetCtx[Out any](ctx context.Context, url string, opts ...Option) (Out, error) {
 	body, _, err := do[Out](c, ctx, methodGet, url, nil, opts)
 	return body, err
@@ -117,6 +147,19 @@ func (c *Client) GetCtx[Out any](ctx context.Context, url string, opts ...Option
 
 // PostCtx issues a context-aware POST request and decodes its response.
 // @group Requests (Context)
+//
+// Example: client context-aware POST
+//
+//	type CreateUser struct { Name string `json:"name"` }
+//	type CreateUserResponse struct { JSON CreateUser `json:"json"` }
+//	ctx := context.Background()
+//	c := httpx.New()
+//	res, err := c.PostCtx[CreateUserResponse](ctx, "https://httpbin.org/post", CreateUser{Name: "Ana"})
+//	if err != nil {
+//		return
+//	}
+//	fmt.Println(res.JSON.Name)
+//	// Ana
 func (c *Client) PostCtx[Out any](ctx context.Context, url string, body any, opts ...Option) (Out, error) {
 	out, _, err := do[Out](c, ctx, methodPost, url, body, opts)
 	return out, err
@@ -124,6 +167,19 @@ func (c *Client) PostCtx[Out any](ctx context.Context, url string, body any, opt
 
 // PutCtx issues a context-aware PUT request and decodes its response.
 // @group Requests (Context)
+//
+// Example: client context-aware PUT
+//
+//	type UpdateUser struct { Name string `json:"name"` }
+//	type UpdateUserResponse struct { JSON UpdateUser `json:"json"` }
+//	ctx := context.Background()
+//	c := httpx.New()
+//	res, err := c.PutCtx[UpdateUserResponse](ctx, "https://httpbin.org/put", UpdateUser{Name: "Ana"})
+//	if err != nil {
+//		return
+//	}
+//	fmt.Println(res.JSON.Name)
+//	// Ana
 func (c *Client) PutCtx[Out any](ctx context.Context, url string, body any, opts ...Option) (Out, error) {
 	out, _, err := do[Out](c, ctx, methodPut, url, body, opts)
 	return out, err
@@ -131,6 +187,19 @@ func (c *Client) PutCtx[Out any](ctx context.Context, url string, body any, opts
 
 // PatchCtx issues a context-aware PATCH request and decodes its response.
 // @group Requests (Context)
+//
+// Example: client context-aware PATCH
+//
+//	type UpdateUser struct { Name string `json:"name"` }
+//	type UpdateUserResponse struct { JSON UpdateUser `json:"json"` }
+//	ctx := context.Background()
+//	c := httpx.New()
+//	res, err := c.PatchCtx[UpdateUserResponse](ctx, "https://httpbin.org/patch", UpdateUser{Name: "Ana"})
+//	if err != nil {
+//		return
+//	}
+//	fmt.Println(res.JSON.Name)
+//	// Ana
 func (c *Client) PatchCtx[Out any](ctx context.Context, url string, body any, opts ...Option) (Out, error) {
 	out, _, err := do[Out](c, ctx, methodPatch, url, body, opts)
 	return out, err
@@ -138,6 +207,20 @@ func (c *Client) PatchCtx[Out any](ctx context.Context, url string, body any, op
 
 // DeleteCtx issues a context-aware DELETE request and decodes its response.
 // @group Requests (Context)
+//
+// Example: client context-aware DELETE
+//
+//	type DeleteResponse struct {
+//		URL string `json:"url"`
+//	}
+//	ctx := context.Background()
+//	c := httpx.New()
+//	res, err := c.DeleteCtx[DeleteResponse](ctx, "https://httpbin.org/delete")
+//	if err != nil {
+//		return
+//	}
+//	fmt.Println(res.URL)
+//	// https://httpbin.org/delete
 func (c *Client) DeleteCtx[Out any](ctx context.Context, url string, opts ...Option) (Out, error) {
 	body, _, err := do[Out](c, ctx, methodDelete, url, nil, opts)
 	return body, err
@@ -145,6 +228,14 @@ func (c *Client) DeleteCtx[Out any](ctx context.Context, url string, opts ...Opt
 
 // HeadCtx issues a context-aware HEAD request and decodes its response using the established response contract.
 // @group Requests (Context)
+//
+// Example: client context-aware HEAD
+//
+//	ctx := context.Background()
+//	c := httpx.New()
+//	_, err := c.HeadCtx[[]byte](ctx, "https://httpbin.org/get")
+//	fmt.Println(err == nil)
+//	// true
 func (c *Client) HeadCtx[Out any](ctx context.Context, url string, opts ...Option) (Out, error) {
 	body, _, err := do[Out](c, ctx, methodHead, url, nil, opts)
 	return body, err
@@ -152,6 +243,14 @@ func (c *Client) HeadCtx[Out any](ctx context.Context, url string, opts ...Optio
 
 // OptionsCtx issues a context-aware OPTIONS request and decodes its response.
 // @group Requests (Context)
+//
+// Example: client context-aware OPTIONS
+//
+//	ctx := context.Background()
+//	c := httpx.New()
+//	_, err := c.OptionsCtx[[]byte](ctx, "https://httpbin.org/get")
+//	fmt.Println(err == nil)
+//	// true
 func (c *Client) OptionsCtx[Out any](ctx context.Context, url string, opts ...Option) (Out, error) {
 	body, _, err := do[Out](c, ctx, methodOptions, url, nil, opts)
 	return body, err

--- a/generic_methods.go
+++ b/generic_methods.go
@@ -1,0 +1,158 @@
+package httpx
+
+import "context"
+
+// Get issues a GET request and decodes its response.
+// @group Requests
+//
+// Example: bind to a struct
+//
+//	type GetResponse struct {
+//		URL string `json:"url"`
+//	}
+//
+//	c := httpx.New()
+//	res, _ := c.Get[GetResponse]("https://httpbin.org/get")
+//	httpx.Dump(res) // dumps GetResponse
+func (c *Client) Get[Out any](url string, opts ...Option) (Out, error) {
+	body, _, err := do[Out](c, nil, methodGet, url, nil, opts)
+	return body, err
+}
+
+// Post issues a POST request and decodes its response.
+// @group Requests
+//
+// Example: typed POST
+//
+//	type CreateUser struct { Name string `json:"name"` }
+//	type CreateUserResponse struct { JSON CreateUser `json:"json"` }
+//
+//	c := httpx.New()
+//	res, err := c.Post[CreateUserResponse]("https://httpbin.org/post", CreateUser{Name: "Ana"})
+//	if err != nil {
+//		return
+//	}
+//	httpx.Dump(res) // dumps CreateUserResponse
+func (c *Client) Post[Out any](url string, body any, opts ...Option) (Out, error) {
+	out, _, err := do[Out](c, nil, methodPost, url, body, opts)
+	return out, err
+}
+
+// Put issues a PUT request and decodes its response.
+// @group Requests
+//
+// Example: typed PUT
+//
+//	type UpdateUser struct { Name string `json:"name"` }
+//	type UpdateUserResponse struct { JSON UpdateUser `json:"json"` }
+//
+//	c := httpx.New()
+//	res, err := c.Put[UpdateUserResponse]("https://httpbin.org/put", UpdateUser{Name: "Ana"})
+//	if err != nil {
+//		return
+//	}
+//	httpx.Dump(res) // dumps UpdateUserResponse
+func (c *Client) Put[Out any](url string, body any, opts ...Option) (Out, error) {
+	out, _, err := do[Out](c, nil, methodPut, url, body, opts)
+	return out, err
+}
+
+// Patch issues a PATCH request and decodes its response.
+// @group Requests
+//
+// Example: typed PATCH
+//
+//	type UpdateUser struct { Name string `json:"name"` }
+//	type UpdateUserResponse struct { JSON UpdateUser `json:"json"` }
+//
+//	c := httpx.New()
+//	res, err := c.Patch[UpdateUserResponse]("https://httpbin.org/patch", UpdateUser{Name: "Ana"})
+//	if err != nil {
+//		return
+//	}
+//	httpx.Dump(res) // dumps UpdateUserResponse
+func (c *Client) Patch[Out any](url string, body any, opts ...Option) (Out, error) {
+	out, _, err := do[Out](c, nil, methodPatch, url, body, opts)
+	return out, err
+}
+
+// Delete issues a DELETE request and decodes its response.
+// @group Requests
+//
+// Example: typed DELETE
+//
+//	type DeleteResponse struct { URL string `json:"url"` }
+//
+//	c := httpx.New()
+//	res, err := c.Delete[DeleteResponse]("https://httpbin.org/delete")
+//	if err != nil {
+//		return
+//	}
+//	httpx.Dump(res) // dumps DeleteResponse
+func (c *Client) Delete[Out any](url string, opts ...Option) (Out, error) {
+	body, _, err := do[Out](c, nil, methodDelete, url, nil, opts)
+	return body, err
+}
+
+// Head issues a HEAD request and decodes its response using the established response contract.
+// @group Requests
+func (c *Client) Head[Out any](url string, opts ...Option) (Out, error) {
+	body, _, err := do[Out](c, nil, methodHead, url, nil, opts)
+	return body, err
+}
+
+// Options issues an OPTIONS request and decodes its response.
+// @group Requests
+func (c *Client) Options[Out any](url string, opts ...Option) (Out, error) {
+	body, _, err := do[Out](c, nil, methodOptions, url, nil, opts)
+	return body, err
+}
+
+// GetCtx issues a context-aware GET request and decodes its response.
+// @group Requests (Context)
+func (c *Client) GetCtx[Out any](ctx context.Context, url string, opts ...Option) (Out, error) {
+	body, _, err := do[Out](c, ctx, methodGet, url, nil, opts)
+	return body, err
+}
+
+// PostCtx issues a context-aware POST request and decodes its response.
+// @group Requests (Context)
+func (c *Client) PostCtx[Out any](ctx context.Context, url string, body any, opts ...Option) (Out, error) {
+	out, _, err := do[Out](c, ctx, methodPost, url, body, opts)
+	return out, err
+}
+
+// PutCtx issues a context-aware PUT request and decodes its response.
+// @group Requests (Context)
+func (c *Client) PutCtx[Out any](ctx context.Context, url string, body any, opts ...Option) (Out, error) {
+	out, _, err := do[Out](c, ctx, methodPut, url, body, opts)
+	return out, err
+}
+
+// PatchCtx issues a context-aware PATCH request and decodes its response.
+// @group Requests (Context)
+func (c *Client) PatchCtx[Out any](ctx context.Context, url string, body any, opts ...Option) (Out, error) {
+	out, _, err := do[Out](c, ctx, methodPatch, url, body, opts)
+	return out, err
+}
+
+// DeleteCtx issues a context-aware DELETE request and decodes its response.
+// @group Requests (Context)
+func (c *Client) DeleteCtx[Out any](ctx context.Context, url string, opts ...Option) (Out, error) {
+	body, _, err := do[Out](c, ctx, methodDelete, url, nil, opts)
+	return body, err
+}
+
+// HeadCtx issues a context-aware HEAD request and decodes its response using the established response contract.
+// @group Requests (Context)
+func (c *Client) HeadCtx[Out any](ctx context.Context, url string, opts ...Option) (Out, error) {
+	body, _, err := do[Out](c, ctx, methodHead, url, nil, opts)
+	return body, err
+}
+
+// OptionsCtx issues a context-aware OPTIONS request and decodes its response.
+// @group Requests (Context)
+func (c *Client) OptionsCtx[Out any](ctx context.Context, url string, opts ...Option) (Out, error) {
+	body, _, err := do[Out](c, ctx, methodOptions, url, nil, opts)
+	return body, err
+}

--- a/generic_methods_bench_test.go
+++ b/generic_methods_bench_test.go
@@ -1,0 +1,51 @@
+package httpx
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// benchmarkRoundTripper adapts a function into an in-process HTTP transport.
+type benchmarkRoundTripper func(*http.Request) (*http.Response, error)
+
+// benchmarkHTTPResponse is the decoded payload used by the hot-path measurement.
+type benchmarkHTTPResponse struct {
+	Name string `json:"name"`
+}
+
+// RoundTrip executes the benchmark transport callback.
+func (roundTrip benchmarkRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	return roundTrip(request)
+}
+
+// BenchmarkGenericGet compares the compatibility function and client method without network noise.
+func BenchmarkGenericGet(b *testing.B) {
+	transport := benchmarkRoundTripper(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"name":"Ada"}`)),
+			Request:    request,
+		}, nil
+	})
+	c := New(Transport(transport))
+
+	b.Run("Function", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			if _, err := Get[benchmarkHTTPResponse](c, "https://example.test"); err != nil {
+				b.Fatalf("Get: %v", err)
+			}
+		}
+	})
+	b.Run("Method", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			if _, err := c.Get[benchmarkHTTPResponse]("https://example.test"); err != nil {
+				b.Fatalf("Get: %v", err)
+			}
+		}
+	})
+}

--- a/generic_methods_test.go
+++ b/generic_methods_test.go
@@ -1,0 +1,100 @@
+package httpx
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// genericMethodResponse is the shared response shape for generic method tests.
+type genericMethodResponse struct {
+	Method string `json:"method"`
+}
+
+// TestGenericMethodSurface verifies every verb and context variant uses the receiver client.
+func TestGenericMethodSurface(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodHead {
+			_, _ = fmt.Fprintf(w, `{"method":%q}`, r.Method)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	c := New()
+	ctx := context.Background()
+
+	// Generic method expressions and values must remain usable as callbacks.
+	get := (*Client).Get[genericMethodResponse]
+	getCtx := c.GetCtx[genericMethodResponse]
+	_ = (*Client).Post[genericMethodResponse]
+	_ = (*Client).Put[genericMethodResponse]
+	_ = (*Client).Patch[genericMethodResponse]
+	_ = (*Client).Delete[genericMethodResponse]
+	_ = (*Client).Head[string]
+	_ = (*Client).Options[genericMethodResponse]
+	_ = (*Client).PostCtx[genericMethodResponse]
+	_ = (*Client).PutCtx[genericMethodResponse]
+	_ = (*Client).PatchCtx[genericMethodResponse]
+	_ = (*Client).DeleteCtx[genericMethodResponse]
+	_ = (*Client).HeadCtx[string]
+	_ = (*Client).OptionsCtx[genericMethodResponse]
+
+	tests := []struct {
+		name       string
+		wantMethod string
+		call       func() (genericMethodResponse, error)
+	}{
+		{"get", http.MethodGet, func() (genericMethodResponse, error) { return get(c, server.URL) }},
+		{"post", http.MethodPost, func() (genericMethodResponse, error) { return c.Post[genericMethodResponse](server.URL, nil) }},
+		{"put", http.MethodPut, func() (genericMethodResponse, error) {
+			return c.Put[genericMethodResponse](server.URL, map[string]string{"name": "Ada"})
+		}},
+		{"patch", http.MethodPatch, func() (genericMethodResponse, error) {
+			return c.Patch[genericMethodResponse](server.URL, map[string]string{"name": "Grace"})
+		}},
+		{"delete", http.MethodDelete, func() (genericMethodResponse, error) { return c.Delete[genericMethodResponse](server.URL) }},
+		{"options", http.MethodOptions, func() (genericMethodResponse, error) { return c.Options[genericMethodResponse](server.URL) }},
+		{"get_ctx", http.MethodGet, func() (genericMethodResponse, error) { return getCtx(ctx, server.URL) }},
+		{"post_ctx", http.MethodPost, func() (genericMethodResponse, error) { return c.PostCtx[genericMethodResponse](ctx, server.URL, nil) }},
+		{"put_ctx", http.MethodPut, func() (genericMethodResponse, error) {
+			return c.PutCtx[genericMethodResponse](ctx, server.URL, map[string]string{"name": "Ada"})
+		}},
+		{"patch_ctx", http.MethodPatch, func() (genericMethodResponse, error) {
+			return c.PatchCtx[genericMethodResponse](ctx, server.URL, map[string]string{"name": "Grace"})
+		}},
+		{"delete_ctx", http.MethodDelete, func() (genericMethodResponse, error) { return c.DeleteCtx[genericMethodResponse](ctx, server.URL) }},
+		{"options_ctx", http.MethodOptions, func() (genericMethodResponse, error) { return c.OptionsCtx[genericMethodResponse](ctx, server.URL) }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.call()
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			if got.Method != test.wantMethod {
+				t.Fatalf("method = %q, want %q", got.Method, test.wantMethod)
+			}
+		})
+	}
+
+	if got, err := c.Head[string](server.URL); err != nil || got != "" {
+		t.Fatalf("Head = %q, err %v", got, err)
+	}
+	if got, err := c.HeadCtx[string](ctx, server.URL); err != nil || got != "" {
+		t.Fatalf("HeadCtx = %q, err %v", got, err)
+	}
+}
+
+// TestGenericContextMethodCancellation verifies context variants forward cancellation to the request.
+func TestGenericContextMethodCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := New().GetCtx[genericMethodResponse](ctx, "https://example.invalid")
+	if err == nil {
+		t.Fatal("expected canceled request error")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goforj/httpx/v2
 
-go 1.24.4
+go 1.27.0
 
 require (
 	github.com/goforj/godump v1.9.0


### PR DESCRIPTION
## What

Add Go 1.27 generic methods for `Get`, `Post`, `Put`, `Patch`, `Delete`, `Head`, and `Options`, including every context-aware variant. Existing package functions keep their two-type-parameter signatures, and `Do` remains a package function because it operates on `req.Request` rather than `Client`.

Raise the module to Go 1.27, cover the minimum version and stable in CI, and update installation guidance for consumers staying on Go 1.26 or earlier. Receiver-aware documentation generation now presents methods and compatibility functions independently.

## Before and after

Every typed verb now starts from the client that owns transport behavior, defaults, and error mapping. No existing verb is renamed or removed.

### Get

Before:

```go
result, err := httpx.Get[Result](client, url)
```

After:

```go
result, err := client.Get[Result](url)
```

### Post

Before:

```go
result, err := httpx.Post[Input, Result](client, url, input)
```

After:

```go
result, err := client.Post[Result](url, input)
```

### Put

Before:

```go
result, err := httpx.Put[Input, Result](client, url, input)
```

After:

```go
result, err := client.Put[Result](url, input)
```

### Patch

Before:

```go
result, err := httpx.Patch[Input, Result](client, url, input)
```

After:

```go
result, err := client.Patch[Result](url, input)
```

### Delete

Before:

```go
result, err := httpx.Delete[Result](client, url)
```

After:

```go
result, err := client.Delete[Result](url)
```

### Head

Before:

```go
result, err := httpx.Head[Result](client, url)
```

After:

```go
result, err := client.Head[Result](url)
```

### Options

Before:

```go
result, err := httpx.Options[Result](client, url)
```

After:

```go
result, err := client.Options[Result](url)
```

### GetCtx

Before:

```go
result, err := httpx.GetCtx[Result](client, ctx, url)
```

After:

```go
result, err := client.GetCtx[Result](ctx, url)
```

### PostCtx

Before:

```go
result, err := httpx.PostCtx[Input, Result](client, ctx, url, input)
```

After:

```go
result, err := client.PostCtx[Result](ctx, url, input)
```

### PutCtx

Before:

```go
result, err := httpx.PutCtx[Input, Result](client, ctx, url, input)
```

After:

```go
result, err := client.PutCtx[Result](ctx, url, input)
```

### PatchCtx

Before:

```go
result, err := httpx.PatchCtx[Input, Result](client, ctx, url, input)
```

After:

```go
result, err := client.PatchCtx[Result](ctx, url, input)
```

### DeleteCtx

Before:

```go
result, err := httpx.DeleteCtx[Result](client, ctx, url)
```

After:

```go
result, err := client.DeleteCtx[Result](ctx, url)
```

### HeadCtx

Before:

```go
result, err := httpx.HeadCtx[Result](client, ctx, url)
```

After:

```go
result, err := client.HeadCtx[Result](ctx, url)
```

### OptionsCtx

Before:

```go
result, err := httpx.OptionsCtx[Result](client, ctx, url)
```

After:

```go
result, err := client.OptionsCtx[Result](ctx, url)
```

Body-bearing methods need only the response type; request bodies are accepted as normal values. That removes a redundant type argument and makes all 14 operations discoverable from `Client`.

## Why

Passing a client as the first argument was a language constraint, not the natural shape of the API. Go 1.27 lets HTTPX put typed verbs where developers look for them, while the compatibility functions ensure upgrades do not force a migration.

## Performance

Methods call the existing request engine directly, without adding another wrapper to the request path. In-process GET benchmarks keep both forms at 51 allocations and about 9.59 KB per request, with both forms in the same roughly 6.2–6.7 microsecond range on linux/arm64 with one P.
